### PR TITLE
Drop kotlin-gradle-plugin dependency which prevented applying kotlin("jvm") in buildSrc/build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,6 @@ kotlin {
 }
 
 dependencies {
-    implementation(libs.kotlin.gradle.plugin) { version { prefer(embeddedKotlinVersion) } }
-
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.junit.jupiter.params)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,5 @@ axion-release = { id = "pl.allegro.tech.build.axion-release", version.ref = "axi
 test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 
 [libraries]
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin" }
 kotest-assertions = { group = "io.kotest", name = "kotest-assertions-core-jvm", version.ref = "kotest" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit-jupiter" }

--- a/src/main/kotlin/dev/panuszewski/gradle/catalog/CatalogAccessorsPlugin.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/catalog/CatalogAccessorsPlugin.kt
@@ -43,6 +43,7 @@ internal class CatalogAccessorsPlugin : Plugin<Project> {
             .filterIsInstance<VersionCatalogBuilderInternal>()
 
     companion object {
+        // TODO separated source sets for generated Java and Kotlin files
         internal const val GENERATED_SOURCES_DIR = "build/generated-sources/typesafe-conventions/kotlin"
     }
 }

--- a/src/main/kotlin/dev/panuszewski/gradle/catalog/LibraryCatalogAccessorsSupport.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/catalog/LibraryCatalogAccessorsSupport.kt
@@ -11,8 +11,6 @@ import org.gradle.api.internal.catalog.LibrariesSourceGenerator
 import org.gradle.api.problems.Problems
 import org.gradle.internal.management.VersionCatalogBuilderInternal
 import org.gradle.kotlin.dsl.support.serviceOf
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.StringWriter
 
 internal object LibraryCatalogAccessorsSupport {
@@ -37,7 +35,7 @@ internal object LibraryCatalogAccessorsSupport {
                 outputs.files.singleFile.writeText(source)
             }
         }
-        project.tasks.withType<KotlinCompile>().configureEach {
+        project.tasks.named("compileKotlin") {
             dependsOn(generateEntrypointTask)
         }
     }
@@ -53,7 +51,7 @@ internal object LibraryCatalogAccessorsSupport {
                 file.writeText(source)
             }
         }
-        project.tasks.withType<KotlinCompile>().configureEach {
+        project.tasks.named("compileKotlin") {
             dependsOn(generateAccessorsTask)
         }
     }

--- a/src/main/kotlin/dev/panuszewski/gradle/catalog/PluginCatalogAccessorsSupport.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/catalog/PluginCatalogAccessorsSupport.kt
@@ -8,8 +8,6 @@ import org.gradle.api.Project
 import org.gradle.api.internal.catalog.DefaultVersionCatalog
 import org.gradle.internal.management.VersionCatalogBuilderInternal
 import org.gradle.kotlin.dsl.add
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 
 internal object PluginCatalogAccessorsSupport {
@@ -72,7 +70,7 @@ internal object PluginCatalogAccessorsSupport {
                 outputs.files.singleFile.writeText(source)
             }
         }
-        project.tasks.withType<KotlinCompile>().configureEach {
+        project.tasks.named("compileKotlin") {
             dependsOn(generateEntrypointTask)
         }
     }


### PR DESCRIPTION
The `typesafe-conventions` plugin has dependency on `kotlin-gradle-plugin`. 

Because of that, trying to apply in `buildSrc/build.gradle.kts`:
```kotlin
plugins {
    kotlin("jvm") version "..."
}
```
or
```kotlin
plugins {
    embeddedKotlin("jvm")
}
```
used to fail with the following error:
```
* What went wrong:
Error resolving plugin [id: 'org.jetbrains.kotlin.jvm', version: '2.0.21']
> The request for this plugin could not be satisfied because the plugin is already on the classpath with an unknown version, so compatibility cannot be checked.
```

This PR drops the `kotlin-gradle-plugin` dependency and replaces references to `KotlinCompile` tasks by type by references by `compileKotlin` name.