### PR TITLE
Broaden convention plugins discovery scope

### DIFF
--- a/src/main/kotlin/dev/panuszewski/gradle/util/GradleUtils.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/util/GradleUtils.kt
@@ -2,9 +2,12 @@ package dev.panuszewski.gradle.util
 
 import dev.panuszewski.gradle.TypesafeConventionsExtension
 import org.gradle.api.Project
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.util.GradleVersion
 
@@ -25,3 +28,9 @@ internal val Project.typesafeConventions: TypesafeConventionsExtension
 
 internal val Settings.typesafeConventions: TypesafeConventionsExtension
     get() = extensions.getByType()
+
+internal val Project.sourceSets: SourceSetContainer
+    get() = extensions.getByName("sourceSets") as SourceSetContainer
+
+internal val SourceSet.kotlin: SourceDirectorySet
+    get() = extensions.getByName("kotlin") as SourceDirectorySet

--- a/src/test/kotlin/dev/panuszewski/gradle/ConventionPluginsSpec.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/ConventionPluginsSpec.kt
@@ -5,6 +5,7 @@ import dev.panuszewski.gradle.fixtures.CustomBuildDirPath
 import dev.panuszewski.gradle.fixtures.ImportedCatalog
 import dev.panuszewski.gradle.fixtures.LibsInDependenciesBlock
 import dev.panuszewski.gradle.fixtures.LibsInPluginsBlock
+import dev.panuszewski.gradle.fixtures.LibsInPluginsBlockInCustomLocation
 import dev.panuszewski.gradle.fixtures.MultiLevelBuildHierarchy
 import dev.panuszewski.gradle.fixtures.MultipleCatalogsInDependenciesBlock
 import dev.panuszewski.gradle.fixtures.MultipleCatalogsInPluginsBlock
@@ -258,5 +259,40 @@ class ConventionPluginsSpec : GradleSpec() {
         result.buildOutcome shouldBe BUILD_SUCCESSFUL
         result.output shouldContain fixture.someLibrary
         result.output shouldNotContain "${fixture.someLibrary} FAILED"
+    }
+
+    @ParameterizedTest
+    @SupportedIncludedBuilds
+    fun `should discover convention plugins in custom source directory under main source set`(includedBuild: Fixture<*>) {
+        // given
+        installFixture(includedBuild)
+        val fixture = installFixture(LibsInPluginsBlockInCustomLocation) {
+            sourceSet = "main"
+            sourceDirectory = "custom"
+        }
+
+        // when
+        val result = runGradle("tasks")
+
+        // then
+        result.buildOutcome shouldBe BUILD_SUCCESSFUL
+        result.output shouldContain fixture.taskRegisteredByPlugin
+    }
+
+    @ParameterizedTest
+    @SupportedIncludedBuilds
+    fun `should not discover convention plugins under non-main source set`(includedBuild: Fixture<*>) {
+        // given
+        installFixture(includedBuild)
+        installFixture(LibsInPluginsBlockInCustomLocation) {
+            sourceSet = "test"
+            sourceDirectory = "custom"
+        }
+
+        // when
+        val result = runGradle("tasks")
+
+        // then
+        result.buildOutcome shouldBe BUILD_FAILED
     }
 }

--- a/src/test/kotlin/dev/panuszewski/gradle/fixtures/ConventionPluginInCustomLocation.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/fixtures/ConventionPluginInCustomLocation.kt
@@ -1,0 +1,62 @@
+package dev.panuszewski.gradle.fixtures
+
+import dev.panuszewski.gradle.fixtures.ConventionPluginInCustomLocation.Config
+import dev.panuszewski.gradle.framework.Fixture
+import dev.panuszewski.gradle.framework.GradleSpec
+
+/**
+ * Similar to [ConventionPlugin], but with custom source directory for convention plugins
+ */
+object ConventionPluginInCustomLocation : Fixture<Config> {
+
+    override fun GradleSpec.install(config: Config) {
+        buildGradleKts {
+            """
+            plugins {
+                id("${config.pluginName}")
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            """
+        }
+
+        includedBuild {
+            customProjectFile("${config.sourceDirectory}/${config.pluginName}.gradle.kts") {
+                config.pluginBody.trimIndent()
+            }
+
+            buildGradleKts {
+                """
+                plugins {
+                    `kotlin-dsl-base`
+                }
+                
+                repositories {
+                    gradlePluginPortal()
+                }
+
+                kotlin {
+                    sourceSets {
+                        named("${config.sourceSet}") {
+                            kotlin.srcDir("${config.sourceDirectory}")
+                        }
+                    }
+                }
+
+                apply(plugin = "org.gradle.kotlin.kotlin-dsl")
+                """
+            }
+        }
+    }
+
+    override fun defaultConfig() = Config()
+
+    class Config {
+        var pluginName: String = "some-convention"
+        var pluginBody: String = ""
+        var sourceSet: String? = null
+        var sourceDirectory: String? = null
+    }
+}

--- a/src/test/kotlin/dev/panuszewski/gradle/fixtures/LibsInPluginsBlockInCustomLocation.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/fixtures/LibsInPluginsBlockInCustomLocation.kt
@@ -1,0 +1,41 @@
+package dev.panuszewski.gradle.fixtures
+
+import dev.panuszewski.gradle.fixtures.LibsInPluginsBlockInCustomLocation.Config
+import dev.panuszewski.gradle.framework.Fixture
+import dev.panuszewski.gradle.framework.GradleSpec
+
+object LibsInPluginsBlockInCustomLocation : Fixture<Config> {
+
+    const val pluginId = "pl.allegro.tech.build.axion-release"
+    const val pluginVersion = "1.18.16"
+    const val taskRegisteredByPlugin = "verifyRelease"
+
+    override fun GradleSpec.install(config: Config) {
+        installFixture(TypesafeConventionsAppliedToIncludedBuild)
+
+        installFixture(ConventionPluginInCustomLocation) {
+            pluginName = "some-convention"
+            pluginBody = """
+                plugins {
+                    alias(libs.plugins.some.plugin)
+                }
+                """
+            sourceSet = config.sourceSet
+            sourceDirectory = config.sourceDirectory
+        }
+
+        libsVersionsToml {
+            """
+            [plugins]
+            some-plugin = { id = "$pluginId", version = "$pluginVersion" }
+            """
+        }
+    }
+
+    override fun defaultConfig() = Config()
+
+    data class Config(
+        var sourceSet: String? = null,
+        var sourceDirectory: String? = null
+    )
+}


### PR DESCRIPTION
~~Previously the plugin hardcoded `src/main/kotlin` as the script directory; this update allows configuring it with a new property on the extension.~~

Update: As per discussion below, this now automatically scans all configured Kotlin source directories in
the `main` source set instead.