### PR TITLE
Support rich versions for the plugins

### DIFF
--- a/src/main/kotlin/dev/panuszewski/gradle/PluginMarker.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/PluginMarker.kt
@@ -18,7 +18,7 @@ public fun Project.pluginMarker(provider: Provider<PluginDependency>): Dependenc
     )
 }
 
-private fun Project.dependencyWithRichVersion(group: String, name: String, versionConstraint: VersionConstraint) =
+internal fun Project.dependencyWithRichVersion(group: String, name: String, versionConstraint: VersionConstraint) =
     dependencies.create("$group:$name") {
         version {
             versionConstraint.strictVersion.takeIf(String::isNotBlank)?.let(::strictly)

--- a/src/main/kotlin/dev/panuszewski/gradle/PluginMarker.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/PluginMarker.kt
@@ -18,7 +18,7 @@ public fun Project.pluginMarker(provider: Provider<PluginDependency>): Dependenc
     )
 }
 
-internal fun Project.dependencyWithRichVersion(group: String, name: String, versionConstraint: VersionConstraint) =
+private fun Project.dependencyWithRichVersion(group: String, name: String, versionConstraint: VersionConstraint) =
     dependencies.create("$group:$name") {
         version {
             versionConstraint.strictVersion.takeIf(String::isNotBlank)?.let(::strictly)

--- a/src/main/kotlin/dev/panuszewski/gradle/TypesafeConventionsPlugin.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/TypesafeConventionsPlugin.kt
@@ -4,6 +4,7 @@ import dev.panuszewski.gradle.catalog.BuilderCatalogContributor
 import dev.panuszewski.gradle.catalog.CatalogAccessorsPlugin
 import dev.panuszewski.gradle.catalog.CatalogContributor
 import dev.panuszewski.gradle.catalog.TomlCatalogContributor
+import dev.panuszewski.gradle.util.BuildHierarchy
 import dev.panuszewski.gradle.util.currentGradleVersion
 import dev.panuszewski.gradle.util.gradleVersionAtLeast
 import dev.panuszewski.gradle.util.typesafeConventions

--- a/src/main/kotlin/dev/panuszewski/gradle/TypesafeConventionsPlugin.kt
+++ b/src/main/kotlin/dev/panuszewski/gradle/TypesafeConventionsPlugin.kt
@@ -4,16 +4,13 @@ import dev.panuszewski.gradle.catalog.BuilderCatalogContributor
 import dev.panuszewski.gradle.catalog.CatalogAccessorsPlugin
 import dev.panuszewski.gradle.catalog.CatalogContributor
 import dev.panuszewski.gradle.catalog.TomlCatalogContributor
-import dev.panuszewski.gradle.util.BuildHierarchy
 import dev.panuszewski.gradle.util.currentGradleVersion
 import dev.panuszewski.gradle.util.gradleVersionAtLeast
-import dev.panuszewski.gradle.util.typesafeConventions
 import dev.panuszewski.gradle.verification.LazyVerificationPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
@@ -142,4 +139,3 @@ internal class TypesafeConventionsPlugin @Inject constructor(
         internal const val MINIMAL_GRADLE_VERSION = "8.7"
     }
 }
-

--- a/src/test/kotlin/dev/panuszewski/gradle/fixtures/OverriddenPluginVersion.kt
+++ b/src/test/kotlin/dev/panuszewski/gradle/fixtures/OverriddenPluginVersion.kt
@@ -1,0 +1,32 @@
+package dev.panuszewski.gradle.fixtures
+
+import dev.panuszewski.gradle.framework.GradleSpec
+import dev.panuszewski.gradle.framework.NoConfigFixture
+
+object OverriddenPluginVersion : NoConfigFixture {
+
+    const val pluginId = LibsInPluginsBlock.pluginId
+    const val pluginVersion = LibsInPluginsBlock.pluginVersion
+    const val pluginMarker = LibsInPluginsBlock.pluginMarker
+    const val overriddenPluginVersion = "1.18.15"
+
+    override fun GradleSpec.install() {
+        installFixture(LibsInPluginsBlock)
+
+        // and
+        val overriddenPluginVersion = "1.18.15"
+
+        // and
+        includedBuild {
+            buildGradleKts {
+                append {
+                    """
+                    dependencies {
+                        implementation("$pluginMarker:$overriddenPluginVersion")
+                    }
+                    """
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The following type of config in `libs.verisons.toml`:
```
[plugins]
kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.prefer = "2.2.20" }
```
used to fail with the error:
```
* What went wrong:
Execution failed for task ':buildSrc:generateExternalPluginSpecBuilders'.
> Could not resolve all files for configuration ':buildSrc:compileClasspath'.
   > Could not find org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:{prefer 2.2.20}.
```
This PR fixes that!